### PR TITLE
DOC: SSO heading

### DIFF
--- a/docs/plio-for-teams/README.md
+++ b/docs/plio-for-teams/README.md
@@ -8,8 +8,8 @@ We provide the following support for organizations:
 -  An organizational workspace to house all the plios created by the organization members.
 -  Members of a workspace can view/edit/analyse the plios created by other members.
 -  [Integration with BigQuery](#data-analysis-using-bigquery) to enable you to build custom dashboards.
--  [Custom authentication](#custom-authentication) in case you want your viewers to bypass Plio's authentication layer.
+-  [Single Sign-On (SSO)](#single-sign-on-sso) in case you want your viewers to bypass Plio's authentication layer.
 
 !!!include(./docs/plio-for-teams/getting-started.md)!!!
 !!!include(./docs/plio-for-teams/data-bigquery.md)!!!
-!!!include(./docs/plio-for-teams/custom-authentication.md)!!!
+!!!include(./docs/plio-for-teams/single-sign-on.md)!!!

--- a/docs/plio-for-teams/single-sign-on.md
+++ b/docs/plio-for-teams/single-sign-on.md
@@ -1,4 +1,4 @@
-## Custom Authentication
+## Single Sign-On (SSO)
 
 Your viewers can watch your plio using the link that you share with them. However, if someone is not already logged in to Plio, they will have to authenticate themselves first. Sometimes, this is not desirable as it can cause additional friction for your viewer and you might want them to directly watch the plio without having to log in.
 
@@ -9,8 +9,6 @@ Plio provides you with a way to do precisely that. You can do this using a uniqu
 It is your responsibility to ensure that you don't share this API key with anyone or include it in any document that is publicly accessible.
 
 :::
-
-### Use your own authentication system with Plio
 
 This is how a typical plio link looks like: 
 


### PR DESCRIPTION
Renamed custom-authentication to SSO and removed redundant sub-heading.
Have tested on staging: https://staging-docs.plio.in